### PR TITLE
[feat] report 테이블 추가

### DIFF
--- a/db/init/init.sql
+++ b/db/init/init.sql
@@ -47,6 +47,21 @@ CREATE TABLE store_input (
     FOREIGN KEY (member_id) REFERENCES members(id)
 );
 
+CREATE TABLE report (
+    id BIGSERIAL PRIMARY KEY,
+    member_id BIGINT NOT NULL,
+    store_input_id BIGINT NOT NULL,
+    total_store_count INT NOT NULL,
+    density DECIMAL(8, 2) NOT NULL,
+    score BIGINT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    comment TEXT,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    FOREIGN KEY (member_id) REFERENCES members(id),
+    FOREIGN KEY (store_input_id) REFERENCES store_input(id)
+);
+
 
 ALTER TABLE store ADD CONSTRAINT uq_store_csv_id UNIQUE (csv_id);
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 services:
   db:
-    image: postgis/postgis:16-3.4
+    image: kartoza/postgis:16-3.4
     container_name: rebo-db
+    platform: linux/arm64/v8
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
### 🚀 Summary

상권분석 결과를 저장하기 위한 report 테이블을 추가하고, PostgreSQL 컨테이너 설정을 구성함.

---

### ✨ Description

#### 1. report 테이블 추가
- 상권분석 결과 저장을 위한 테이블 스키마 정의
  - 필수 컬럼: id, member_id, store_input_id, total_store_count, density, score, status
  - 메타 데이터: comment, created_at, updated_at
  - 외래키: members, store_input 테이블 참조

#### 2. PostgreSQL 컨테이너 설정
- PostgreSQL 및 PostGIS 설정
- 환경변수 관리를 위한 .env 파일 연동
- 초기화 스크립트 마운트 설정

#### 테스트 결과
- [x] 컨테이너 정상 실행
- [x] report 테이블 생성 확인
- [x] 외래키 제약조건 동작 확인

![image](https://github.com/user-attachments/assets/87d6cd6a-25f1-40ff-a5b2-327259c0f5a9)

---

### 🎲 Issue Number

close #12