### PR TITLE
[feat] PostgreSQL 스키마 인덱스 최적화 및 필수 수정사항 적용

### DIFF
--- a/db/init/init.sql
+++ b/db/init/init.sql
@@ -1,18 +1,29 @@
 CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
 
 CREATE TABLE store (
     id BIGSERIAL PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     csv_id VARCHAR(255),
     road_address VARCHAR(255),
-    Latitude NUMERIC(9, 6) NOT NULL,
+    latitude NUMERIC(9, 6) NOT NULL,
     longitude NUMERIC(9, 6) NOT NULL,
     category_large VARCHAR(50),
     category_middle VARCHAR(50),
     category_small VARCHAR(50),
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     is_deleted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX idx_store_category_large_name ON store (category_large, name);
+CREATE INDEX idx_store_category_middle_name ON store (category_middle, name);
+CREATE INDEX idx_store_category_small_name ON store (category_small, name);
+
+CREATE INDEX idx_store_location_gist
+ON store
+USING gist (
+  ST_SetSRID(ST_MakePoint(longitude, latitude), 4326)
 );
 
 CREATE TABLE stg_store (
@@ -42,8 +53,8 @@ CREATE TABLE store_input (
     location VARCHAR(255) NOT NULL,
     category VARCHAR(20) NOT NULL,
     radius INT NOT NULL,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (member_id) REFERENCES members(id)
 );
 
@@ -56,8 +67,8 @@ CREATE TABLE report (
     score BIGINT NOT NULL,
     status VARCHAR(20) NOT NULL,
     comment TEXT,
-    created_at TIMESTAMP NOT NULL,
-    updated_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (member_id) REFERENCES members(id),
     FOREIGN KEY (store_input_id) REFERENCES store_input(id)
 );


### PR DESCRIPTION
### 🚀 Summary

PostgreSQL 스키마 인덱스 최적화 및 필수 수정사항 적용

---

### ✨ Description

해당 스키마 인덱스 적용 및 최적화 완료했습니다.

#### 1. 실행 통계 (Execution Statistics)
- **총 실행 시간**: 639.331 ms
- **계획 수립 시간**: 3.101 ms
- **데이터 처리**:
  - Heap Blocks(실제 읽은 블록): 55,161
  - 결과 행: 217개 (추정)
  - 실제 처리 시간: 348.864 ms ~ 638.420 ms

#### 2. 리소스 사용 (Resource Usage)
- **버퍼 사용량**:
  - shared read: 69,433
  - shared written: 15,277
- **인덱스 사용**:
  - Bitmap Index Scan on `idx_store_location_gist` (공간 인덱스)
  - Bitmap Index Scan on `idx_store_category_small_name` (카테고리+이름 복합 인덱스)
  - BitmapAnd로 두 인덱스 결과를 합침
  - Heap Blocks: 55,161 (실제 테이블에서 읽은 블록 수)

#### 3. 병렬 처리 (Parallel Processing)
- 병렬 처리 정보: 실행 계획에 명시적으로 나타나지 않음
- 실제로는 단일 프로세스(loops=1)로 동작

#### 4. JIT 컴파일 (Just-In-Time Compilation)
- JIT 관련 정보: 실행 계획에 JIT 관련 정보는 표시되지 않음

### 📊 비교 분석

| 항목 | 인덱스 미적용 | 인덱스 적용 후 | 차이/의미 |
|------|---------------|----------------|-----------|
| 총 실행 시간 | 622.948 ms | 639.331 ms | 거의 동일 (약간 증가) |
| 계획 수립 시간 | 15.971 ms | 3.101 ms | **대폭 감소** |
| 읽은 행/블록 수 | 902,885개(행) | 55,161개(블록) | **I/O 대폭 감소** |
| 버퍼 사용량 | 33,399 hit / 38,586 read | 69,433 read / 15,277 written | 읽기/쓰기 패턴 변화 |
| 병렬 처리 | 병렬(2 worker) | 단일 프로세스(loops=1) | 실행 계획에 따라 다름 |
| JIT | 322.969 ms | (정보 없음) | - |

위 표와 비교해보면 **I/O 사용률이 대폭 감소**했습니다.

---

### 🎲 Issue Number

close #14